### PR TITLE
Step0本番: 実データ寸法で判定モジュールを検証

### DIFF
--- a/tests/test_step0_realdata.py
+++ b/tests/test_step0_realdata.py
@@ -15,6 +15,14 @@ class Step0RealDataTests(unittest.TestCase):
         self.assertEqual(box_size("A", 0), (1400, 1000, 800))
         self.assertEqual(box_size("A", 90), (1000, 1400, 800))
 
+    def test_orientation_invalid_yaw_ng(self) -> None:
+        with self.assertRaises(ValueError):
+            box_size("A", 45)
+
+    def test_unknown_box_type_ng(self) -> None:
+        with self.assertRaises(ValueError):
+            box_size("Z", 0)
+
     def test_inside_container_boundary_ok_with_90deg_rotation(self) -> None:
         # A box at exact max boundary with 90deg orientation should still be valid.
         box = place_box("A", x=5898 - 1000, y=2352 - 1400, z=2393 - 800, yaw_deg=90)
@@ -52,4 +60,3 @@ class Step0RealDataTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/vanning/problem_spec.py
+++ b/vanning/problem_spec.py
@@ -1,4 +1,4 @@
-"""バンニング問題で共通利用する定数・補助関数。"""
+﻿"""バンニング問題で共通利用する定数・補助関数。"""
 
 from vanning.geometry import BoxPlacement, Container, oriented_size
 
@@ -7,7 +7,7 @@ from vanning.geometry import BoxPlacement, Container, oriented_size
 CONTAINER_20FT = Container(l=5898, w=2352, h=2393)
 
 # 箱タイプごとの外形寸法 [mm]（長さ, 幅, 高さ）
-BOX_DIMS = {
+BOX_DIMS: dict[str, tuple[int, int, int]] = {
     "A": (1400, 1000, 800),
     "B": (1200, 900, 700),
     "C": (800, 600, 600),
@@ -15,15 +15,19 @@ BOX_DIMS = {
 
 
 def box_size(box_type: str, yaw_deg: int) -> tuple[float, float, float]:
-    """箱タイプと向き(0°/90°)から、実際に使う寸法を返す。"""
+    """箱タイプと向き(0°/90°)から、実際に使う寸法[mm]を返す。"""
+    if yaw_deg not in {0, 90}:
+        raise ValueError(f"yaw_deg は 0 または 90 を指定してください: {yaw_deg}")
+
     key = box_type.upper()
     if key not in BOX_DIMS:
         raise ValueError(f"未知の box_type です: {box_type}")
+
     length, width, height = BOX_DIMS[key]
     return oriented_size(length, width, height, yaw_deg)
 
 
 def place_box(box_type: str, x: float, y: float, z: float, yaw_deg: int) -> BoxPlacement:
-    """箱タイプ・座標・向きから BoxPlacement を生成する。"""
+    """箱タイプ・座標[mm]・向き(0°/90°)から BoxPlacement を生成する。"""
     l, w, h = box_size(box_type, yaw_deg)
     return BoxPlacement(x=x, y=y, z=z, l=l, w=w, h=h)


### PR DESCRIPTION
## Summary
- `vanning/problem_spec.py` を追加し、20ftコンテナ寸法と A/B/C 箱寸法を定数化
- 向き 0°/90° を反映する `box_size` と、配置生成用 `place_box` を追加
- Step0 本番問題向けに `tests/test_step0_realdata.py` を追加
  - 実寸法で 0°/90° 向き確認
  - 境界ちょうどOK / はみ出しNG
  - 面接触は衝突なし / 内部重なりは衝突あり
  - 数箱の非衝突配置サンプル

## Test
- `python -m unittest discover -s tests -v`

Closes #3