### PR TITLE
Step1: 本番2Dデータ適用と可視化を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
+artifacts/
 

--- a/scripts/run_step1_realdata_2d.py
+++ b/scripts/run_step1_realdata_2d.py
@@ -1,0 +1,35 @@
+"""Step1: 本番2Dデータ適用 + 可視化を実行するスクリプト。"""
+
+from collections import Counter
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from vanning.problem_spec import CONTAINER_20FT, build_step1_2d_realdata_items
+from vanning.step1_2d import pack_2d_by_destination_ffd
+from vanning.step1_2d_visualization import save_packing_summary_svgs
+
+
+def main() -> None:
+    items = build_step1_2d_realdata_items(allow_rotate=True)
+    summary = pack_2d_by_destination_ffd(
+        items,
+        bin_length=CONTAINER_20FT.l,
+        bin_width=CONTAINER_20FT.w,
+    )
+    output_dir = Path("artifacts/step1_2d_realdata")
+    files = save_packing_summary_svgs(summary, output_dir)
+
+    counts = Counter(bin_.dest for bin_ in summary.bins)
+    print(f"items: {len(items)}")
+    print(f"bins: {summary.bin_count} (X={counts.get('X', 0)}, Y={counts.get('Y', 0)})")
+    print(f"total unused area: {summary.total_unused_area:.0f} mm^2")
+    print(f"svg files: {len(files)}")
+    print(f"output directory: {output_dir.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_step1_2d_realdata.py
+++ b/tests/test_step1_2d_realdata.py
@@ -1,0 +1,85 @@
+import tempfile
+import unittest
+from collections import Counter
+from pathlib import Path
+
+from vanning.problem_spec import (
+    BOX_DIMS,
+    CONTAINER_20FT,
+    box_type_from_id,
+    build_step1_2d_realdata_items,
+    destination_for_box_id,
+    realdata_box_ids,
+)
+from vanning.step1_2d import pack_2d_by_destination_ffd
+from vanning.step1_2d_visualization import save_packing_summary_svgs
+
+
+def _placements_overlap(a, b) -> bool:
+    return a.x < b.x_max and a.x_max > b.x and a.y < b.y_max and a.y_max > b.y
+
+
+class Step1TwoDimensionalRealDataTests(unittest.TestCase):
+    def test_realdata_ids_and_destinations(self) -> None:
+        ids = realdata_box_ids()
+        self.assertEqual(len(ids), 80)
+        self.assertEqual(ids[0], "A01")
+        self.assertEqual(ids[-1], "C20")
+
+        dest_counts = Counter(destination_for_box_id(item_id) for item_id in ids)
+        self.assertEqual(dest_counts["X"], 40)
+        self.assertEqual(dest_counts["Y"], 40)
+
+    def test_realdata_item_build(self) -> None:
+        items = build_step1_2d_realdata_items()
+        self.assertEqual(len(items), 80)
+
+        for item in items:
+            box_type = box_type_from_id(item.item_id)
+            length, width, _ = BOX_DIMS[box_type]
+            self.assertEqual((item.length, item.width), (float(length), float(width)))
+            self.assertIn(item.dest, {"X", "Y"})
+
+    def test_realdata_2d_packing_is_valid(self) -> None:
+        items = build_step1_2d_realdata_items()
+        summary = pack_2d_by_destination_ffd(
+            items,
+            bin_length=CONTAINER_20FT.l,
+            bin_width=CONTAINER_20FT.w,
+        )
+
+        self.assertGreater(summary.bin_count, 0)
+
+        for bin_ in summary.bins:
+            self.assertTrue(all(p.item.dest == bin_.dest for p in bin_.placements))
+            for placement in bin_.placements:
+                self.assertGreaterEqual(placement.x, 0)
+                self.assertGreaterEqual(placement.y, 0)
+                self.assertLessEqual(placement.x_max, CONTAINER_20FT.l)
+                self.assertLessEqual(placement.y_max, CONTAINER_20FT.w)
+
+            for i in range(len(bin_.placements)):
+                for j in range(i + 1, len(bin_.placements)):
+                    self.assertFalse(_placements_overlap(bin_.placements[i], bin_.placements[j]))
+
+    def test_realdata_visualization_svg_generation(self) -> None:
+        items = build_step1_2d_realdata_items()
+        summary = pack_2d_by_destination_ffd(
+            items,
+            bin_length=CONTAINER_20FT.l,
+            bin_width=CONTAINER_20FT.w,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp)
+            files = save_packing_summary_svgs(summary, output_dir)
+            self.assertEqual(len(files), summary.bin_count)
+            for file_path in files:
+                self.assertTrue(file_path.exists())
+                content = file_path.read_text(encoding="utf-8")
+                self.assertIn("<svg", content)
+                self.assertIn("Bin", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vanning/problem_spec.py
+++ b/vanning/problem_spec.py
@@ -1,4 +1,4 @@
-﻿"""バンニング問題で共通利用する定数・補助関数。"""
+"""バンニング問題で共通利用する定数・補助関数。"""
 
 from vanning.geometry import BoxPlacement, Container, oriented_size
 
@@ -11,6 +11,13 @@ BOX_DIMS: dict[str, tuple[int, int, int]] = {
     "A": (1400, 1000, 800),
     "B": (1200, 900, 700),
     "C": (800, 600, 600),
+}
+
+# 問題インスタンスで使う箱数（IDレンジ）
+REALDATA_BOX_COUNTS: dict[str, int] = {
+    "A": 30,
+    "B": 30,
+    "C": 20,
 }
 
 
@@ -31,3 +38,60 @@ def place_box(box_type: str, x: float, y: float, z: float, yaw_deg: int) -> BoxP
     """箱タイプ・座標[mm]・向き(0°/90°)から BoxPlacement を生成する。"""
     l, w, h = box_size(box_type, yaw_deg)
     return BoxPlacement(x=x, y=y, z=z, l=l, w=w, h=h)
+
+
+def realdata_box_ids() -> list[str]:
+    """問題インスタンスで使う箱ID一覧を返す。"""
+    ids: list[str] = []
+    for box_type, count in REALDATA_BOX_COUNTS.items():
+        for idx in range(1, count + 1):
+            ids.append(f"{box_type}{idx:02d}")
+    return ids
+
+
+def box_type_from_id(box_id: str) -> str:
+    """箱IDから箱タイプ（A/B/C）を返す。"""
+    if len(box_id) < 3:
+        raise ValueError(f"不正な箱IDです: {box_id}")
+    box_type = box_id[0].upper()
+    if box_type not in BOX_DIMS:
+        raise ValueError(f"未知の箱タイプです: {box_id}")
+    return box_type
+
+
+def destination_for_box_id(box_id: str) -> str:
+    """箱IDに対応する行先(X/Y)を返す。"""
+    box_type = box_type_from_id(box_id)
+    try:
+        serial = int(box_id[1:])
+    except ValueError as exc:
+        raise ValueError(f"不正な箱IDです: {box_id}") from exc
+
+    count = REALDATA_BOX_COUNTS[box_type]
+    if serial < 1 or serial > count:
+        raise ValueError(f"箱IDの連番が範囲外です: {box_id}")
+
+    if box_type in {"A", "B"}:
+        return "X" if serial <= 15 else "Y"
+    return "X" if serial <= 10 else "Y"
+
+
+def build_step1_2d_realdata_items(allow_rotate: bool = True) -> list["Item2D"]:
+    """Step1-2D 用に、本番データ80箱を Item2D の配列へ変換する。"""
+    # 循環参照を避けるため、必要時に import する。
+    from vanning.step1_2d import Item2D
+
+    items: list[Item2D] = []
+    for box_id in realdata_box_ids():
+        box_type = box_type_from_id(box_id)
+        length, width, _ = BOX_DIMS[box_type]
+        items.append(
+            Item2D(
+                item_id=box_id,
+                length=float(length),
+                width=float(width),
+                dest=destination_for_box_id(box_id),
+                allow_rotate=allow_rotate,
+            )
+        )
+    return items

--- a/vanning/step1_2d_visualization.py
+++ b/vanning/step1_2d_visualization.py
@@ -1,0 +1,135 @@
+"""Step1-2D パッキング結果の可視化（SVG 出力）。"""
+
+from html import escape
+from pathlib import Path
+
+from vanning.step1_2d import Bin2D, PackingSummary2D, PlacedItem2D
+
+
+_BOX_COLORS: dict[str, str] = {
+    "A": "#4E79A7",
+    "B": "#F28E2B",
+    "C": "#59A14F",
+}
+_DEFAULT_COLOR = "#BAB0AC"
+
+
+def _box_type_from_item_id(item_id: str) -> str:
+    if not item_id:
+        return "?"
+    return item_id[0].upper()
+
+
+def _fill_color(placement: PlacedItem2D) -> str:
+    return _BOX_COLORS.get(_box_type_from_item_id(placement.item.item_id), _DEFAULT_COLOR)
+
+
+def render_bin_layout_svg(
+    bin_: Bin2D,
+    *,
+    title: str | None = None,
+    pixels_per_mm: float = 0.09,
+    margin_px: int = 36,
+) -> str:
+    """1コンテナ分の2D床面レイアウトを SVG 文字列として返す。"""
+    if pixels_per_mm <= 0:
+        raise ValueError("pixels_per_mm must be positive")
+    if margin_px < 0:
+        raise ValueError("margin_px must be non-negative")
+
+    panel_length = int(round(bin_.capacity_length * pixels_per_mm))
+    panel_width = int(round(bin_.capacity_width * pixels_per_mm))
+    footer_height = 56
+    svg_width = panel_length + margin_px * 2
+    svg_height = panel_width + margin_px * 2 + footer_height
+
+    def to_x(mm: float) -> float:
+        return margin_px + mm * pixels_per_mm
+
+    # SVG の y は上向きに増えるため、床面座標(y=0)を下側に合わせる。
+    def to_y(mm: float) -> float:
+        return margin_px + (bin_.capacity_width - mm) * pixels_per_mm
+
+    top = margin_px
+    left = margin_px
+    right = left + panel_length
+    bottom = top + panel_width
+    title_text = title or f"Dest {bin_.dest} layout ({len(bin_.placements)} items)"
+
+    lines: list[str] = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        (
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{svg_width}" '
+            f'height="{svg_height}" viewBox="0 0 {svg_width} {svg_height}">'
+        ),
+        '<rect x="0" y="0" width="100%" height="100%" fill="#F8F9FB"/>',
+        f'<text x="{left}" y="22" font-size="16" font-family="Segoe UI, sans-serif" '
+        f'fill="#1F2937">{escape(title_text)}</text>',
+        (
+            f'<rect x="{left}" y="{top}" width="{panel_length}" height="{panel_width}" '
+            'fill="#FFFFFF" stroke="#1F2937" stroke-width="2"/>'
+        ),
+    ]
+
+    for placement in sorted(bin_.placements, key=lambda p: (p.y, p.x, p.item.item_id)):
+        x = to_x(placement.x)
+        y = to_y(placement.y + placement.width)
+        w = placement.length * pixels_per_mm
+        h = placement.width * pixels_per_mm
+        label = placement.item.item_id
+        if placement.rotated:
+            label += " (R)"
+
+        lines.append(
+            (
+                f'<rect x="{x:.2f}" y="{y:.2f}" width="{w:.2f}" height="{h:.2f}" '
+                f'fill="{_fill_color(placement)}" fill-opacity="0.88" '
+                'stroke="#111827" stroke-width="1"/>'
+            )
+        )
+        lines.append(
+            f'<text x="{x + w / 2:.2f}" y="{y + h / 2:.2f}" text-anchor="middle" '
+            'dominant-baseline="middle" font-size="10" font-family="Consolas, monospace" '
+            f'fill="#111827">{escape(label)}</text>'
+        )
+
+    util = 1.0 - (bin_.remaining_area / (bin_.capacity_length * bin_.capacity_width))
+    lines.extend(
+        [
+            f'<text x="{left}" y="{bottom + 24}" font-size="13" '
+            'font-family="Segoe UI, sans-serif" fill="#374151">'
+            f'Dest: {escape(bin_.dest)}  Items: {len(bin_.placements)}  Utilization: {util:.1%}'
+            "</text>",
+            f'<text x="{right}" y="{bottom + 24}" text-anchor="end" font-size="12" '
+            'font-family="Consolas, monospace" fill="#6B7280">'
+            f"L={int(bin_.capacity_length)}mm W={int(bin_.capacity_width)}mm"
+            "</text>",
+            "</svg>",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def save_packing_summary_svgs(
+    summary: PackingSummary2D,
+    output_dir: str | Path,
+    *,
+    prefix: str = "step1_2d_realdata",
+    pixels_per_mm: float = 0.09,
+) -> list[Path]:
+    """パッキング結果をコンテナごとに SVG ファイルとして保存する。"""
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    generated: list[Path] = []
+    for idx, bin_ in enumerate(summary.bins, start=1):
+        file_path = out_dir / f"{prefix}_bin{idx:02d}_{bin_.dest}.svg"
+        svg = render_bin_layout_svg(
+            bin_,
+            title=f"Bin {idx:02d} (Dest {bin_.dest})",
+            pixels_per_mm=pixels_per_mm,
+        )
+        file_path.write_text(svg, encoding="utf-8")
+        generated.append(file_path)
+
+    return generated


### PR DESCRIPTION
## 概要
- Step1-2D向けに本番データ80箱（A/B/C, Dest X/Y）を Item2D へ変換するユーティリティを追加
- 2Dパッキング結果をコンテナごとにSVG出力する可視化モジュールを追加
- 実行スクリプト scripts/run_step1_realdata_2d.py を追加し、実データへの適用と可視化を一発実行可能にした
- 実データ向けの妥当性テスト（行先混載なし・境界内・非重複・SVG生成）を追加

## 実行結果（実データ80箱）
- bins: 8 (X=4, Y=4)
- total unused area: 26976768 mm^2
- output: rtifacts/step1_2d_realdata/*.svg`n
## テスト
- python -m unittest discover -s tests`n
Closes #10