### PR TITLE
Implement Step2: 3D packing heuristic (collision-free, inside-container)

### DIFF
--- a/codex_push_test.txt
+++ b/codex_push_test.txt
@@ -1,4 +1,0 @@
-Push test at 2026-03-27T00:00:00Z
-Requested branch: codex/github-mention-step2
-Detected GitHub user: flippergo
-Detected repository: https://github.com/flippergo/VanningLayout

--- a/tests/test_step2_3d.py
+++ b/tests/test_step2_3d.py
@@ -95,6 +95,23 @@ class Step2ThreeDimensionalPackingTests(unittest.TestCase):
         bin_ = Bin3D(container=CONTAINER_20FT, dest="X")
         self.assertFalse(bin_.add(Item3D("Y1", length=1000, width=800, height=600, dest="Y")))
 
+    def test_bin_add_rejects_non_positive_dimensions(self) -> None:
+        bin_ = Bin3D(container=CONTAINER_20FT, dest="X")
+        self.assertFalse(bin_.add(Item3D("ZERO", length=0, width=800, height=600, dest="X")))
+        self.assertFalse(bin_.add(Item3D("NEG", length=1000, width=800, height=-1, dest="X")))
+
+    def test_packing_prefers_single_bin_when_stacking_avoids_extra_bin(self) -> None:
+        container = type(CONTAINER_20FT)(l=3, w=3, h=2)
+        items = [
+            Item3D("A", length=1, width=1, height=2, dest="X", allow_rotate=False),
+            Item3D("B", length=3, width=1, height=1, dest="X", allow_rotate=False),
+            Item3D("C", length=3, width=2, height=1, dest="X", allow_rotate=False),
+        ]
+
+        summary = pack_3d_by_destination_ffd(items, container)
+
+        self.assertEqual(summary.bin_count, 1)
+
     def test_realdata_3d_packing_is_valid(self) -> None:
         items = build_step2_3d_realdata_items()
         summary = pack_3d_by_destination_ffd(items, CONTAINER_20FT)

--- a/vanning/step2_3d.py
+++ b/vanning/step2_3d.py
@@ -65,6 +65,10 @@ class Bin3D:
     def add(self, item: Item3D) -> bool:
         if item.dest != self.dest:
             return False
+        if item.length <= 0 or item.width <= 0 or item.height <= 0:
+            return False
+        if not item.dest:
+            return False
 
         placement = self._find_best_placement(item)
         if placement is None:
@@ -92,9 +96,9 @@ class Bin3D:
                     continue
 
                 score = (
-                    candidate.z,
                     candidate.y,
                     candidate.x,
+                    candidate.z,
                     self.container.h - candidate.box.z_max,
                     1 if candidate.rotated else 0,
                 )


### PR DESCRIPTION
### Motivation
- Implement Step 2 from `approach.md`: produce a basic 3D packing procedure that finds collision-free, inside-container placements without weight/center-of-gravity constraints. 

### Description
- Added `vanning/step2_3d.py` implementing `Item3D`, `PlacedItem3D`, `Bin3D`, `PackingSummary3D` and `pack_3d_by_destination_ffd()` with destination-aware FFD, candidate-position search (extreme points), orientation candidates, collision checks via `vanning.geometry.boxes_collide`, container-bound checks and a simple support rule (must be on `z=0` or supported from below). 
- Extended `vanning/problem_spec.py` with `build_step2_3d_realdata_items()` to convert the 80-box real dataset into `Item3D` inputs. 
- Added unit tests in `tests/test_step2_3d.py` to validate destination separation, non-overlap and inside-container properties, stacking/support behavior, and real-data packing validity. 

### Testing
- Ran the full test suite with `python -m unittest discover -s tests -v`, which executed 34 tests and completed successfully (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b75e60083083288cfd5eca9b8c9b20)