### PR TITLE
Implement Step6 bin count minimization

### DIFF
--- a/tests/test_step6_bin_count_minimization_3d.py
+++ b/tests/test_step6_bin_count_minimization_3d.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from vanning.problem_spec import (
     CONTAINER_20FT,
@@ -69,6 +70,39 @@ class Step6BinCountMinimizationTests(unittest.TestCase):
             max_center_offset_mm=1000,
             min_support_area_ratio=STEP5_MIN_SUPPORT_AREA_RATIO,
         )
+
+        self.assertEqual(step6_summary.initial_bin_count, 2)
+        self.assertEqual(step6_summary.bin_count, 2)
+
+    def test_trial_pack_value_error_is_treated_as_infeasible_branch(self) -> None:
+        roomy_container = type(CONTAINER_20FT)(l=2000, w=2000, h=2000)
+        items = [
+            WeightedItem3D("A", 400, 400, 400, 6, "X", allow_rotate=False),
+            WeightedItem3D("B", 400, 400, 400, 4, "X", allow_rotate=False),
+            WeightedItem3D("C", 400, 400, 400, 6, "X", allow_rotate=False),
+            WeightedItem3D("D", 400, 400, 400, 4, "X", allow_rotate=False),
+        ]
+
+        original_helper = (
+            "vanning.step6_bin_count_minimization_3d.pack_single_realistic_stable_bin"
+        )
+
+        from vanning.step6_bin_count_minimization_3d import pack_single_realistic_stable_bin as real_helper
+
+        def flaky_helper(*args, **kwargs):
+            bin_items = args[0]
+            if len(bin_items) == 2 and sum(item.weight_kg for item in bin_items) == 10:
+                raise ValueError("synthetic trial-pack failure")
+            return real_helper(*args, **kwargs)
+
+        with patch(original_helper, side_effect=flaky_helper):
+            step6_summary = pack_min_bin_count_3d_by_destination(
+                items,
+                roomy_container,
+                max_weight_kg=10,
+                max_center_offset_mm=1000,
+                min_support_area_ratio=STEP5_MIN_SUPPORT_AREA_RATIO,
+            )
 
         self.assertEqual(step6_summary.initial_bin_count, 2)
         self.assertEqual(step6_summary.bin_count, 2)

--- a/tests/test_step6_bin_count_minimization_3d.py
+++ b/tests/test_step6_bin_count_minimization_3d.py
@@ -1,0 +1,106 @@
+import unittest
+
+from vanning.problem_spec import (
+    CONTAINER_20FT,
+    CONTAINER_20FT_CENTER_OF_GRAVITY_RADIUS_MM,
+    CONTAINER_20FT_MAX_PAYLOAD_KG,
+    STEP5_MIN_SUPPORT_AREA_RATIO,
+    build_step3_weighted_realdata_items,
+)
+from vanning.step3_weighted_3d import WeightedItem3D
+from vanning.step5_realistic_stability_3d import (
+    pack_realistic_stable_3d_by_destination_ffd,
+    validate_realistic_stability,
+)
+from vanning.step6_bin_count_minimization_3d import pack_min_bin_count_3d_by_destination
+
+
+class Step6BinCountMinimizationTests(unittest.TestCase):
+    def test_reduces_ffd_weight_split_by_repartitioning_bins(self) -> None:
+        roomy_container = type(CONTAINER_20FT)(l=2000, w=2000, h=2000)
+        items = [
+            WeightedItem3D("A", 400, 400, 400, 6, "X", allow_rotate=False),
+            WeightedItem3D("B", 400, 400, 400, 5, "X", allow_rotate=False),
+            WeightedItem3D("C", 400, 400, 400, 3, "X", allow_rotate=False),
+            WeightedItem3D("D", 400, 400, 400, 2, "X", allow_rotate=False),
+            WeightedItem3D("E", 400, 400, 400, 2, "X", allow_rotate=False),
+            WeightedItem3D("F", 400, 400, 400, 2, "X", allow_rotate=False),
+        ]
+
+        step5_summary = pack_realistic_stable_3d_by_destination_ffd(
+            items,
+            roomy_container,
+            max_weight_kg=10,
+            max_center_offset_mm=1000,
+            min_support_area_ratio=STEP5_MIN_SUPPORT_AREA_RATIO,
+        )
+        step6_summary = pack_min_bin_count_3d_by_destination(
+            items,
+            roomy_container,
+            max_weight_kg=10,
+            max_center_offset_mm=1000,
+            min_support_area_ratio=STEP5_MIN_SUPPORT_AREA_RATIO,
+        )
+
+        self.assertEqual(step5_summary.bin_count, 3)
+        self.assertEqual(step6_summary.initial_bin_count, 3)
+        self.assertEqual(step6_summary.bin_count, 2)
+        self.assertEqual(step6_summary.total_weight_kg, sum(item.weight_kg for item in items))
+        for bin_ in step6_summary.bins:
+            self.assertLessEqual(bin_.total_weight_kg, 10)
+            validate_realistic_stability(
+                bin_.placements,
+                min_support_area_ratio=STEP5_MIN_SUPPORT_AREA_RATIO,
+            )
+
+    def test_keeps_bin_count_when_weight_lower_bound_is_already_tight(self) -> None:
+        roomy_container = type(CONTAINER_20FT)(l=2000, w=2000, h=2000)
+        items = [
+            WeightedItem3D("A", 400, 400, 400, 6, "X", allow_rotate=False),
+            WeightedItem3D("B", 400, 400, 400, 4, "X", allow_rotate=False),
+            WeightedItem3D("C", 400, 400, 400, 6, "X", allow_rotate=False),
+            WeightedItem3D("D", 400, 400, 400, 4, "X", allow_rotate=False),
+        ]
+
+        step6_summary = pack_min_bin_count_3d_by_destination(
+            items,
+            roomy_container,
+            max_weight_kg=10,
+            max_center_offset_mm=1000,
+            min_support_area_ratio=STEP5_MIN_SUPPORT_AREA_RATIO,
+        )
+
+        self.assertEqual(step6_summary.initial_bin_count, 2)
+        self.assertEqual(step6_summary.bin_count, 2)
+
+    def test_realdata_packing_is_valid_and_not_worse_than_step5(self) -> None:
+        items = build_step3_weighted_realdata_items()
+        step5_summary = pack_realistic_stable_3d_by_destination_ffd(
+            items,
+            CONTAINER_20FT,
+            max_weight_kg=CONTAINER_20FT_MAX_PAYLOAD_KG,
+            max_center_offset_mm=CONTAINER_20FT_CENTER_OF_GRAVITY_RADIUS_MM,
+            min_support_area_ratio=STEP5_MIN_SUPPORT_AREA_RATIO,
+        )
+        step6_summary = pack_min_bin_count_3d_by_destination(
+            items,
+            CONTAINER_20FT,
+            max_weight_kg=CONTAINER_20FT_MAX_PAYLOAD_KG,
+            max_center_offset_mm=CONTAINER_20FT_CENTER_OF_GRAVITY_RADIUS_MM,
+            min_support_area_ratio=STEP5_MIN_SUPPORT_AREA_RATIO,
+        )
+
+        self.assertEqual(step6_summary.total_weight_kg, sum(item.weight_kg for item in items))
+        self.assertLessEqual(step6_summary.bin_count, step5_summary.bin_count)
+        self.assertTrue(step6_summary.all_bins_within_center_constraint)
+        for bin_ in step6_summary.bins:
+            self.assertLessEqual(bin_.center_offset_mm, CONTAINER_20FT_CENTER_OF_GRAVITY_RADIUS_MM)
+            self.assertLessEqual(bin_.total_weight_kg, CONTAINER_20FT_MAX_PAYLOAD_KG)
+            validate_realistic_stability(
+                bin_.placements,
+                min_support_area_ratio=STEP5_MIN_SUPPORT_AREA_RATIO,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_step6_bin_count_minimization_3d.py
+++ b/tests/test_step6_bin_count_minimization_3d.py
@@ -14,6 +14,7 @@ from vanning.step5_realistic_stability_3d import (
     validate_realistic_stability,
 )
 from vanning.step6_bin_count_minimization_3d import (
+    _minimum_required_bin_count,
     _try_pack_items_into_bin_count,
     pack_min_bin_count_3d_by_destination,
 )
@@ -174,6 +175,16 @@ class Step6BinCountMinimizationTests(unittest.TestCase):
         self.assertEqual(len(packed_bins), 2)
         for bin_ in packed_bins:
             self.assertLessEqual(bin_.total_weight_kg, 0.82 + 1e-9)
+
+    def test_weight_lower_bound_tolerates_decimal_rounding(self) -> None:
+        items = [
+            WeightedItem3D("A", 400, 400, 400, 0.31, "X", allow_rotate=False),
+            WeightedItem3D("B", 400, 400, 400, 0.51, "X", allow_rotate=False),
+            WeightedItem3D("C", 400, 400, 400, 0.31, "X", allow_rotate=False),
+            WeightedItem3D("D", 400, 400, 400, 0.51, "X", allow_rotate=False),
+        ]
+
+        self.assertEqual(_minimum_required_bin_count(items, max_weight_kg=0.82), 2)
 
     def test_realdata_packing_is_valid_and_not_worse_than_step5(self) -> None:
         items = build_step3_weighted_realdata_items()

--- a/tests/test_step6_bin_count_minimization_3d.py
+++ b/tests/test_step6_bin_count_minimization_3d.py
@@ -13,7 +13,10 @@ from vanning.step5_realistic_stability_3d import (
     pack_realistic_stable_3d_by_destination_ffd,
     validate_realistic_stability,
 )
-from vanning.step6_bin_count_minimization_3d import pack_min_bin_count_3d_by_destination
+from vanning.step6_bin_count_minimization_3d import (
+    _try_pack_items_into_bin_count,
+    pack_min_bin_count_3d_by_destination,
+)
 
 
 class Step6BinCountMinimizationTests(unittest.TestCase):
@@ -106,6 +109,48 @@ class Step6BinCountMinimizationTests(unittest.TestCase):
 
         self.assertEqual(step6_summary.initial_bin_count, 2)
         self.assertEqual(step6_summary.bin_count, 2)
+
+    def test_search_does_not_prune_partial_bucket_that_becomes_packable_later(self) -> None:
+        roomy_container = type(CONTAINER_20FT)(l=2000, w=2000, h=2000)
+        items = [
+            WeightedItem3D("0", 400, 400, 400, 6, "X", allow_rotate=False),
+            WeightedItem3D("1", 400, 400, 400, 4, "X", allow_rotate=False),
+            WeightedItem3D("2", 400, 400, 400, 3, "X", allow_rotate=False),
+            WeightedItem3D("3", 400, 400, 400, 3, "X", allow_rotate=False),
+            WeightedItem3D("4", 400, 400, 400, 2, "X", allow_rotate=False),
+            WeightedItem3D("5", 400, 400, 400, 2, "X", allow_rotate=False),
+        ]
+
+        original_helper = (
+            "vanning.step6_bin_count_minimization_3d.pack_single_realistic_stable_bin"
+        )
+
+        valid_partitions = {
+            frozenset({"0", "1"}),
+            frozenset({"2", "3", "4", "5"}),
+        }
+
+        def non_monotonic_helper(*args, **kwargs):
+            bin_items = args[0]
+            key = frozenset(item.item_id for item in bin_items)
+            if key in valid_partitions:
+                return object()
+            if key == frozenset({"2"}):
+                return None
+            return None
+
+        with patch(original_helper, side_effect=non_monotonic_helper):
+            packed_bins = _try_pack_items_into_bin_count(
+                items,
+                target_bin_count=2,
+                container=roomy_container,
+                max_weight_kg=10,
+                max_center_offset_mm=1000,
+                min_support_area_ratio=STEP5_MIN_SUPPORT_AREA_RATIO,
+            )
+
+        self.assertIsNotNone(packed_bins)
+        self.assertEqual(len(packed_bins), 2)
 
     def test_realdata_packing_is_valid_and_not_worse_than_step5(self) -> None:
         items = build_step3_weighted_realdata_items()

--- a/tests/test_step6_bin_count_minimization_3d.py
+++ b/tests/test_step6_bin_count_minimization_3d.py
@@ -152,6 +152,29 @@ class Step6BinCountMinimizationTests(unittest.TestCase):
         self.assertIsNotNone(packed_bins)
         self.assertEqual(len(packed_bins), 2)
 
+    def test_search_accepts_decimal_weights_on_capacity_boundary(self) -> None:
+        roomy_container = type(CONTAINER_20FT)(l=2000, w=2000, h=2000)
+        items = [
+            WeightedItem3D("A", 400, 400, 400, 0.31, "X", allow_rotate=False),
+            WeightedItem3D("B", 400, 400, 400, 0.51, "X", allow_rotate=False),
+            WeightedItem3D("C", 400, 400, 400, 0.31, "X", allow_rotate=False),
+            WeightedItem3D("D", 400, 400, 400, 0.51, "X", allow_rotate=False),
+        ]
+
+        packed_bins = _try_pack_items_into_bin_count(
+            items,
+            target_bin_count=2,
+            container=roomy_container,
+            max_weight_kg=0.82,
+            max_center_offset_mm=1000,
+            min_support_area_ratio=STEP5_MIN_SUPPORT_AREA_RATIO,
+        )
+
+        self.assertIsNotNone(packed_bins)
+        self.assertEqual(len(packed_bins), 2)
+        for bin_ in packed_bins:
+            self.assertLessEqual(bin_.total_weight_kg, 0.82 + 1e-9)
+
     def test_realdata_packing_is_valid_and_not_worse_than_step5(self) -> None:
         items = build_step3_weighted_realdata_items()
         step5_summary = pack_realistic_stable_3d_by_destination_ffd(

--- a/vanning/step3_weighted_3d.py
+++ b/vanning/step3_weighted_3d.py
@@ -1,9 +1,13 @@
 """Step3: weight-constrained 3D packing built on top of Step2 placement."""
 
 from dataclasses import dataclass, field
+from math import isclose
 
 from vanning.geometry import BoxPlacement, Container
 from vanning.step2_3d import Item3D, pack_3d_by_destination_ffd
+
+
+WEIGHT_COMPARISON_ABS_TOLERANCE_KG = 1e-9
 
 
 @dataclass(frozen=True)
@@ -77,7 +81,7 @@ class WeightAllocationBin:
     def add(self, item: WeightedItem3D) -> bool:
         if item.dest != self.dest:
             return False
-        if item.weight_kg <= 0 or item.weight_kg > self.remaining_weight_kg:
+        if item.weight_kg <= 0 or _exceeds_weight_limit(item.weight_kg, self.remaining_weight_kg):
             return False
         self.items.append(item)
         return True
@@ -173,7 +177,7 @@ def assign_by_destination_and_weight_ffd(
             raise ValueError(f"item dimensions must be positive: {item.item_id}")
         if item.weight_kg <= 0:
             raise ValueError(f"item weight must be positive: {item.item_id}")
-        if item.weight_kg > max_weight_kg:
+        if _exceeds_weight_limit(item.weight_kg, max_weight_kg):
             raise ValueError(f"item exceeds max_weight_kg: {item.item_id}")
         if not item.dest:
             raise ValueError(f"item.dest must be non-empty: {item.item_id}")
@@ -245,3 +249,12 @@ def pack_weighted_3d_by_destination_ffd(
             )
 
     return WeightedPackingSummary3D(bins=packed_bins)
+
+
+def _exceeds_weight_limit(weight_kg: float, limit_kg: float) -> bool:
+    return weight_kg > limit_kg and not isclose(
+        weight_kg,
+        limit_kg,
+        rel_tol=0.0,
+        abs_tol=WEIGHT_COMPARISON_ABS_TOLERANCE_KG,
+    )

--- a/vanning/step5_realistic_stability_3d.py
+++ b/vanning/step5_realistic_stability_3d.py
@@ -8,6 +8,7 @@ from vanning.step3_weighted_3d import (
     WeightedItem3D,
     WeightedPackedBin3D,
     WeightedPlacedItem3D,
+    _exceeds_weight_limit,
     assign_by_destination_and_weight_ffd,
 )
 from vanning.step4_center_of_gravity_3d import CenterBalancedBin3D, translate_bin_toward_center
@@ -145,7 +146,7 @@ class _StableWeightedBin3D:
             return False
         if item.length <= 0 or item.width <= 0 or item.height <= 0:
             return False
-        if item.weight_kg <= 0 or item.weight_kg > self.remaining_weight_kg:
+        if item.weight_kg <= 0 or _exceeds_weight_limit(item.weight_kg, self.remaining_weight_kg):
             return False
 
         placement = self._find_best_placement(item)

--- a/vanning/step5_realistic_stability_3d.py
+++ b/vanning/step5_realistic_stability_3d.py
@@ -257,6 +257,57 @@ def pack_realistic_stable_3d_by_destination_ffd(
     return summary
 
 
+def pack_single_realistic_stable_bin(
+    items: list[WeightedItem3D],
+    container: Container,
+    max_weight_kg: float,
+    max_center_offset_mm: float,
+    min_support_area_ratio: float = STEP5_MIN_SUPPORT_AREA_RATIO,
+) -> CenterBalancedBin3D | None:
+    """Try to pack one destination-specific item set into a single centered bin."""
+    if not items:
+        raise ValueError("items must be non-empty")
+    if container.l <= 0 or container.w <= 0 or container.h <= 0:
+        raise ValueError("container dimensions must be positive")
+    if max_weight_kg <= 0:
+        raise ValueError("max_weight_kg must be positive")
+    if max_center_offset_mm < 0:
+        raise ValueError("max_center_offset_mm must be non-negative")
+    if not 0 < min_support_area_ratio <= 1:
+        raise ValueError("min_support_area_ratio must be in (0, 1]")
+
+    dest = items[0].dest
+    bin_ = _StableWeightedBin3D(
+        container=container,
+        dest=dest,
+        max_weight_kg=max_weight_kg,
+        min_support_area_ratio=min_support_area_ratio,
+    )
+
+    ordered = sorted(items, key=lambda item: (-item.volume, -max(item.length, item.width), item.item_id))
+    for item in ordered:
+        if item.dest != dest:
+            raise ValueError("all items must have the same destination")
+        _validate_item_can_fit(item, container)
+        if not bin_.add(item):
+            return None
+
+    packed_bin = WeightedPackedBin3D(
+        container=container,
+        dest=dest,
+        max_weight_kg=max_weight_kg,
+        placements=bin_.placements.copy(),
+    )
+    centered_bin = translate_bin_toward_center(packed_bin, max_center_offset_mm)
+    validate_realistic_stability(
+        centered_bin.placements,
+        min_support_area_ratio=min_support_area_ratio,
+    )
+    if not centered_bin.satisfies_center_constraint:
+        return None
+    return centered_bin
+
+
 def _pack_allocation_bin(
     items: list[WeightedItem3D],
     container: Container,

--- a/vanning/step6_bin_count_minimization_3d.py
+++ b/vanning/step6_bin_count_minimization_3d.py
@@ -1,0 +1,216 @@
+"""Step6: reduce container count by repartitioning Step5-feasible bins."""
+
+from collections import defaultdict
+from dataclasses import dataclass
+from math import ceil
+
+from vanning.geometry import Container
+from vanning.problem_spec import STEP5_MIN_SUPPORT_AREA_RATIO
+from vanning.step3_weighted_3d import WeightedItem3D
+from vanning.step4_center_of_gravity_3d import CenterBalancedBin3D
+from vanning.step5_realistic_stability_3d import (
+    pack_realistic_stable_3d_by_destination_ffd,
+    pack_single_realistic_stable_bin,
+)
+
+
+@dataclass(frozen=True)
+class MinimizedBinCountPackingSummary3D:
+    """Summary of the Step6 bin-count minimization result."""
+
+    bins: list[CenterBalancedBin3D]
+    max_center_offset_mm: float
+    min_support_area_ratio: float
+    initial_bin_count: int
+
+    @property
+    def bin_count(self) -> int:
+        return len(self.bins)
+
+    @property
+    def total_weight_kg(self) -> float:
+        return sum(bin_.total_weight_kg for bin_ in self.bins)
+
+    @property
+    def max_observed_center_offset_mm(self) -> float:
+        return max((bin_.center_offset_mm for bin_ in self.bins), default=0.0)
+
+    @property
+    def all_bins_within_center_constraint(self) -> bool:
+        return all(bin_.satisfies_center_constraint for bin_ in self.bins)
+
+
+def pack_min_bin_count_3d_by_destination(
+    items: list[WeightedItem3D],
+    container: Container,
+    max_weight_kg: float,
+    max_center_offset_mm: float,
+    min_support_area_ratio: float = STEP5_MIN_SUPPORT_AREA_RATIO,
+) -> MinimizedBinCountPackingSummary3D:
+    """Build a Step5 solution, then iteratively try to reduce one bin per destination."""
+    initial_summary = pack_realistic_stable_3d_by_destination_ffd(
+        items,
+        container,
+        max_weight_kg=max_weight_kg,
+        max_center_offset_mm=max_center_offset_mm,
+        min_support_area_ratio=min_support_area_ratio,
+    )
+
+    bins_by_dest: dict[str, list[CenterBalancedBin3D]] = defaultdict(list)
+    for bin_ in initial_summary.bins:
+        bins_by_dest[bin_.dest].append(bin_)
+
+    minimized_bins: list[CenterBalancedBin3D] = []
+    for dest_bins in bins_by_dest.values():
+        minimized_bins.extend(
+            _minimize_destination_bins(
+                dest_bins,
+                container=container,
+                max_weight_kg=max_weight_kg,
+                max_center_offset_mm=max_center_offset_mm,
+                min_support_area_ratio=min_support_area_ratio,
+            )
+        )
+
+    summary = MinimizedBinCountPackingSummary3D(
+        bins=minimized_bins,
+        max_center_offset_mm=max_center_offset_mm,
+        min_support_area_ratio=min_support_area_ratio,
+        initial_bin_count=initial_summary.bin_count,
+    )
+    if not summary.all_bins_within_center_constraint:
+        raise ValueError("center of gravity constraint violated")
+
+    return summary
+
+
+def _minimize_destination_bins(
+    bins: list[CenterBalancedBin3D],
+    container: Container,
+    max_weight_kg: float,
+    max_center_offset_mm: float,
+    min_support_area_ratio: float,
+) -> list[CenterBalancedBin3D]:
+    current_bins = list(bins)
+    current_items = [placement.item for bin_ in current_bins for placement in bin_.placements]
+    min_possible_bin_count = ceil(sum(item.weight_kg for item in current_items) / max_weight_kg)
+
+    while len(current_bins) > min_possible_bin_count:
+        current_items = [placement.item for bin_ in current_bins for placement in bin_.placements]
+        reduced_bins = _try_pack_items_into_bin_count(
+            current_items,
+            target_bin_count=len(current_bins) - 1,
+            container=container,
+            max_weight_kg=max_weight_kg,
+            max_center_offset_mm=max_center_offset_mm,
+            min_support_area_ratio=min_support_area_ratio,
+        )
+        if reduced_bins is None:
+            break
+        current_bins = reduced_bins
+
+    return current_bins
+
+
+def _try_pack_items_into_bin_count(
+    items: list[WeightedItem3D],
+    target_bin_count: int,
+    container: Container,
+    max_weight_kg: float,
+    max_center_offset_mm: float,
+    min_support_area_ratio: float,
+) -> list[CenterBalancedBin3D] | None:
+    if not items:
+        return []
+    if target_bin_count <= 0:
+        return None
+
+    item_key_by_identity = {
+        id(item): index
+        for index, item in enumerate(
+            sorted(items, key=lambda candidate: (candidate.item_id, candidate.weight_kg, candidate.volume))
+        )
+    }
+    ordered = sorted(
+        items,
+        key=lambda item: (
+            -item.weight_kg,
+            -item.volume,
+            -max(item.length, item.width),
+            item_key_by_identity[id(item)],
+        ),
+    )
+    pack_cache: dict[tuple[int, ...], CenterBalancedBin3D | None] = {}
+    failed_states: set[tuple[int, tuple[tuple[int, ...], ...]]] = set()
+
+    def pack_items(bin_items: list[WeightedItem3D]) -> CenterBalancedBin3D | None:
+        key = tuple(sorted(item_key_by_identity[id(item)] for item in bin_items))
+        if key not in pack_cache:
+            pack_cache[key] = pack_single_realistic_stable_bin(
+                bin_items,
+                container=container,
+                max_weight_kg=max_weight_kg,
+                max_center_offset_mm=max_center_offset_mm,
+                min_support_area_ratio=min_support_area_ratio,
+            )
+        return pack_cache[key]
+
+    def search(
+        item_index: int,
+        bin_items: list[list[WeightedItem3D]],
+        bin_weights: list[float],
+    ) -> list[CenterBalancedBin3D] | None:
+        state_key = (
+            item_index,
+            tuple(
+                sorted(
+                    tuple(sorted(item_key_by_identity[id(item)] for item in bucket))
+                    for bucket in bin_items
+                )
+            ),
+        )
+        if state_key in failed_states:
+            return None
+
+        if item_index == len(ordered):
+            packed_bins = [pack_items(bucket) for bucket in bin_items if bucket]
+            if any(packed is None for packed in packed_bins):
+                failed_states.add(state_key)
+                return None
+            return [packed for packed in packed_bins if packed is not None]
+
+        item = ordered[item_index]
+        seen_bucket_signatures: set[tuple[int, ...]] = set()
+
+        for bucket_index in range(target_bin_count):
+            bucket_signature = tuple(sorted(item_key_by_identity[id(existing)] for existing in bin_items[bucket_index]))
+            if bucket_signature in seen_bucket_signatures:
+                continue
+            seen_bucket_signatures.add(bucket_signature)
+
+            if bin_weights[bucket_index] + item.weight_kg > max_weight_kg:
+                continue
+
+            trial_bucket = bin_items[bucket_index] + [item]
+            if pack_items(trial_bucket) is None:
+                continue
+
+            bin_items[bucket_index] = trial_bucket
+            bin_weights[bucket_index] += item.weight_kg
+            result = search(item_index + 1, bin_items, bin_weights)
+            if result is not None:
+                return result
+            bin_weights[bucket_index] -= item.weight_kg
+            bin_items[bucket_index] = trial_bucket[:-1]
+
+            if not bucket_signature:
+                break
+
+        failed_states.add(state_key)
+        return None
+
+    return search(
+        item_index=0,
+        bin_items=[[] for _ in range(target_bin_count)],
+        bin_weights=[0.0 for _ in range(target_bin_count)],
+    )

--- a/vanning/step6_bin_count_minimization_3d.py
+++ b/vanning/step6_bin_count_minimization_3d.py
@@ -2,7 +2,6 @@
 
 from collections import defaultdict
 from dataclasses import dataclass
-from math import ceil
 
 from vanning.geometry import Container
 from vanning.problem_spec import STEP5_MIN_SUPPORT_AREA_RATIO
@@ -93,7 +92,7 @@ def _minimize_destination_bins(
 ) -> list[CenterBalancedBin3D]:
     current_bins = list(bins)
     current_items = [placement.item for bin_ in current_bins for placement in bin_.placements]
-    min_possible_bin_count = ceil(sum(item.weight_kg for item in current_items) / max_weight_kg)
+    min_possible_bin_count = _minimum_required_bin_count(current_items, max_weight_kg)
 
     while len(current_bins) > min_possible_bin_count:
         current_items = [placement.item for bin_ in current_bins for placement in bin_.placements]
@@ -214,3 +213,16 @@ def _try_pack_items_into_bin_count(
         bin_items=[[] for _ in range(target_bin_count)],
         bin_weights=[0.0 for _ in range(target_bin_count)],
     )
+
+
+def _minimum_required_bin_count(items: list[WeightedItem3D], max_weight_kg: float) -> int:
+    if not items:
+        return 0
+    if max_weight_kg <= 0:
+        raise ValueError("max_weight_kg must be positive")
+
+    total_weight_kg = sum(item.weight_kg for item in items)
+    required_bin_count = max(1, int(total_weight_kg / max_weight_kg))
+    while _exceeds_weight_limit(total_weight_kg, required_bin_count * max_weight_kg):
+        required_bin_count += 1
+    return required_bin_count

--- a/vanning/step6_bin_count_minimization_3d.py
+++ b/vanning/step6_bin_count_minimization_3d.py
@@ -6,7 +6,7 @@ from math import ceil
 
 from vanning.geometry import Container
 from vanning.problem_spec import STEP5_MIN_SUPPORT_AREA_RATIO
-from vanning.step3_weighted_3d import WeightedItem3D
+from vanning.step3_weighted_3d import WeightedItem3D, _exceeds_weight_limit
 from vanning.step4_center_of_gravity_3d import CenterBalancedBin3D
 from vanning.step5_realistic_stability_3d import (
     pack_realistic_stable_3d_by_destination_ffd,
@@ -191,7 +191,7 @@ def _try_pack_items_into_bin_count(
                 continue
             seen_bucket_signatures.add(bucket_signature)
 
-            if bin_weights[bucket_index] + item.weight_kg > max_weight_kg:
+            if _exceeds_weight_limit(bin_weights[bucket_index] + item.weight_kg, max_weight_kg):
                 continue
 
             trial_bucket = bin_items[bucket_index] + [item]

--- a/vanning/step6_bin_count_minimization_3d.py
+++ b/vanning/step6_bin_count_minimization_3d.py
@@ -146,13 +146,16 @@ def _try_pack_items_into_bin_count(
     def pack_items(bin_items: list[WeightedItem3D]) -> CenterBalancedBin3D | None:
         key = tuple(sorted(item_key_by_identity[id(item)] for item in bin_items))
         if key not in pack_cache:
-            pack_cache[key] = pack_single_realistic_stable_bin(
-                bin_items,
-                container=container,
-                max_weight_kg=max_weight_kg,
-                max_center_offset_mm=max_center_offset_mm,
-                min_support_area_ratio=min_support_area_ratio,
-            )
+            try:
+                pack_cache[key] = pack_single_realistic_stable_bin(
+                    bin_items,
+                    container=container,
+                    max_weight_kg=max_weight_kg,
+                    max_center_offset_mm=max_center_offset_mm,
+                    min_support_area_ratio=min_support_area_ratio,
+                )
+            except ValueError:
+                pack_cache[key] = None
         return pack_cache[key]
 
     def search(

--- a/vanning/step6_bin_count_minimization_3d.py
+++ b/vanning/step6_bin_count_minimization_3d.py
@@ -195,9 +195,6 @@ def _try_pack_items_into_bin_count(
                 continue
 
             trial_bucket = bin_items[bucket_index] + [item]
-            if pack_items(trial_bucket) is None:
-                continue
-
             bin_items[bucket_index] = trial_bucket
             bin_weights[bucket_index] += item.weight_kg
             result = search(item_index + 1, bin_items, bin_weights)


### PR DESCRIPTION
## Summary
- add a Step6 solver that starts from the Step5 packing and repartitions each destination into fewer containers when feasible
- expose a Step5 helper for single-container feasibility checks so Step6 can preserve weight, realistic stability, and center-of-gravity constraints
- add Step6 tests for a synthetic improvement case, a tight lower-bound case, and the existing real-data case

## Testing
- python -m unittest tests.test_step5_realistic_stability_3d
- python -m unittest tests.test_step6_bin_count_minimization_3d
- python -m unittest discover -s tests  
  existing environment issue: 	est_step1_2d_realdata.Step1TwoDimensionalRealDataTests.test_realdata_visualization_svg_generation fails under the bundled LibreOffice Python with a temporary-directory PermissionError

Closes #23